### PR TITLE
Add basic IP check and DNS update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# homeIP
-Simple software the updates DNS if your home ip address changes
+# HomeIP
+
+HomeIP periodically checks your public IP address and updates a DNS record when it changes. The DNS provider is pluggable; currently a Leaseweb implementation is included.
+
+## Usage
+
+Set the following environment variables:
+
+- `CHECK_INTERVAL` - seconds between checks (default `300`)
+- `DNS_PROVIDER` - name of the provider (`leaseweb` is the default and only option)
+- `DNS_DOMAIN` - domain name to update
+- `DNS_RECORD` - record name (e.g. `www` or `@`) – defaults to `@`
+- `LEASEWEB_API_TOKEN` - API token for Leaseweb DNS
+
+Install dependencies and run `python -m homeip.main`.

--- a/homeip/__init__.py
+++ b/homeip/__init__.py
@@ -1,0 +1,1 @@
+"""HomeIP package."""

--- a/homeip/dns_provider.py
+++ b/homeip/dns_provider.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+
+
+class DNSProvider(ABC):
+    """Abstract base class for DNS providers."""
+
+    @abstractmethod
+    def update_record(self, domain: str, record: str, ip_address: str) -> None:
+        """Update a DNS record with the given IP address."""
+        raise NotImplementedError

--- a/homeip/dns_providers/__init__.py
+++ b/homeip/dns_providers/__init__.py
@@ -1,0 +1,3 @@
+from .leaseweb import LeasewebDNSProvider
+
+__all__ = ["LeasewebDNSProvider"]

--- a/homeip/dns_providers/leaseweb.py
+++ b/homeip/dns_providers/leaseweb.py
@@ -1,0 +1,26 @@
+import os
+import requests
+from homeip.dns_provider import DNSProvider
+
+
+class LeasewebDNSProvider(DNSProvider):
+    """DNS Provider implementation for Leaseweb."""
+
+    BASE_URL = "https://api.leaseweb.com/v1"
+
+    def __init__(self) -> None:
+        self.token = os.getenv("LEASEWEB_API_TOKEN")
+        if not self.token:
+            raise ValueError("LEASEWEB_API_TOKEN is required")
+
+    def _headers(self):
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+        }
+
+    def update_record(self, domain: str, record: str, ip_address: str) -> None:
+        url = f"{self.BASE_URL}/domains/{domain}/records/{record}"
+        payload = {"content": ip_address, "type": "A", "name": record}
+        response = requests.put(url, json=payload, headers=self._headers())
+        response.raise_for_status()

--- a/homeip/main.py
+++ b/homeip/main.py
@@ -1,0 +1,42 @@
+import os
+import time
+import requests
+
+from homeip.dns_providers import LeasewebDNSProvider
+
+
+CHECK_INTERVAL = int(os.getenv("CHECK_INTERVAL", "300"))
+DNS_PROVIDER = os.getenv("DNS_PROVIDER", "leaseweb").lower()
+DOMAIN = os.getenv("DNS_DOMAIN")
+RECORD_NAME = os.getenv("DNS_RECORD", "@").strip()
+
+
+def get_public_ip() -> str:
+    response = requests.get("https://api.ipify.org")
+    response.raise_for_status()
+    return response.text.strip()
+
+
+def main():
+    if not DOMAIN:
+        raise ValueError("DNS_DOMAIN environment variable is required")
+
+    if DNS_PROVIDER != "leaseweb":
+        raise ValueError(f"Unsupported DNS provider: {DNS_PROVIDER}")
+
+    provider = LeasewebDNSProvider()
+
+    last_ip = None
+    while True:
+        try:
+            current_ip = get_public_ip()
+            if current_ip != last_ip:
+                provider.update_record(DOMAIN, RECORD_NAME, current_ip)
+                last_ip = current_ip
+        except Exception as exc:
+            print(f"Error updating DNS: {exc}")
+        time.sleep(CHECK_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
## Summary
- implement a simple IP watcher
- support pluggable DNS providers with Leaseweb provider
- document environment variable setup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863c9820f5883259d80d130ddcfe2d2