### PR TITLE
Implement DNS record listing on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ Set the following environment variables:
 - `LEASEWEB_API_TOKEN` - API token for Leaseweb DNS
 
 Install dependencies and run `python -m homeip.main`.
+
+On startup the tool lists the current DNS records for the configured domain to
+confirm that the API credentials are valid.

--- a/homeip/dns_provider.py
+++ b/homeip/dns_provider.py
@@ -8,3 +8,8 @@ class DNSProvider(ABC):
     def update_record(self, domain: str, record: str, ip_address: str) -> None:
         """Update a DNS record with the given IP address."""
         raise NotImplementedError
+
+    @abstractmethod
+    def list_records(self, domain: str):
+        """Return DNS records for the given domain."""
+        raise NotImplementedError

--- a/homeip/dns_providers/leaseweb.py
+++ b/homeip/dns_providers/leaseweb.py
@@ -1,6 +1,6 @@
 import os
 import requests
-from dns_provider import DNSProvider
+from ..dns_provider import DNSProvider
 
 
 class LeasewebDNSProvider(DNSProvider):
@@ -24,3 +24,9 @@ class LeasewebDNSProvider(DNSProvider):
         payload = {"content": ip_address, "type": "A", "name": record}
         response = requests.put(url, json=payload, headers=self._headers())
         response.raise_for_status()
+
+    def list_records(self, domain: str):
+        url = f"{self.BASE_URL}/domains/{domain}/records"
+        response = requests.get(url, headers=self._headers())
+        response.raise_for_status()
+        return response.json()

--- a/homeip/main.py
+++ b/homeip/main.py
@@ -2,7 +2,7 @@ import os
 import time
 import requests
 
-from dns_providers import LeasewebDNSProvider
+from .dns_providers import LeasewebDNSProvider
 
 
 CHECK_INTERVAL = int(os.getenv("CHECK_INTERVAL", "300"))
@@ -25,6 +25,12 @@ def main():
         raise ValueError(f"Unsupported DNS provider: {DNS_PROVIDER}")
 
     provider = LeasewebDNSProvider()
+
+    try:
+        records = provider.list_records(DOMAIN)
+        print("Current DNS records:", records)
+    except Exception as exc:
+        print(f"Error retrieving DNS records: {exc}")
 
     last_ip = None
     while True:


### PR DESCRIPTION
## Summary
- add `list_records` abstract method to `DNSProvider`
- implement DNS listing in `LeasewebDNSProvider`
- show DNS records in `main` on startup
- mention the feature in README
- switch to relative imports for package modules

## Testing
- `python -m pip install -r homeip/requirements.txt`
- `python -m homeip.main` *(fails: DNS_DOMAIN env var is required)*
- `DNS_DOMAIN=example.com LEASEWEB_API_TOKEN=token python -m homeip.main` *(fails: proxy blocks access)*

------
https://chatgpt.com/codex/tasks/task_e_6863d35143ec8325bad0de5a3f58308b